### PR TITLE
Basic Firewall Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# XDP Skeleton
+# eBPFun
 
 ## Dependencies
 
@@ -22,12 +22,16 @@ Once all dependencies are installed, run `make`. You can test the output binary 
 
 ## Output
 
-Since this program is just a dead-simple packet counter you can test the program output by running the default configuration and pinging your loopback interface. While running `sudo ping -f localhost` and `sudo ping -f ::1` you should see something like the following output:
+While running `yes | nc -u 127.0.0.1 81` with the configuration file at the top level of this repo you should see something like the following output:
 
 ```bash
 vagrant@ubuntu-jammy:/vagrant$ sudo ./ebpfun -config config.hcl
-2022/03/07 19:11:32 Packets received: IP - 26650, IPv6 - 0
-2022/03/07 19:11:33 Packets received: IP - 100540, IPv6 - 0
-2022/03/07 19:11:36 Packets received: IP - 100540, IPv6 - 101651
-2022/03/07 19:11:37 Packets received: IP - 100540, IPv6 - 182532
+2022/03/08 03:32:04 Packets dropped: 46323
+2022/03/08 03:32:05 Packets dropped: 142811
+2022/03/08 03:32:06 Packets dropped: 227929
+2022/03/08 03:32:07 Packets dropped: 321104
+2022/03/08 03:32:08 Packets dropped: 409536
+2022/03/08 03:32:09 Packets dropped: 505245
+2022/03/08 03:32:10 Packets dropped: 595287
+2022/03/08 03:32:11 Packets dropped: 636769
 ```

--- a/config.go
+++ b/config.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"errors"
+	"net"
+
+	"github.com/andrewstucki/ebpfun/firewall"
+)
+
+type Ingress struct {
+	Address string `hcl:"address"`
+	Port    int    `hcl:"port"`
+}
+
+func parseIP(address string) (net.IP, error) {
+	ip := net.ParseIP(address)
+	if ip == nil || ip.To4() == nil {
+		return nil, errors.New("invalid ip address")
+	}
+	return ip.To4(), nil
+}
+
+func (i Ingress) ToFirewall() (firewall.Ingress, error) {
+	ip, err := parseIP(i.Address)
+	if err != nil {
+		return firewall.Ingress{}, err
+	}
+
+	return firewall.Ingress{
+		Address: ip,
+		Port:    i.Port,
+	}, nil
+}
+
+type Exemption struct {
+	Source      string `hcl:"source"`
+	Destination string `hcl:"destination"`
+	Port        int    `hcl:"port"`
+}
+
+func (e Exemption) ToFirewall() (firewall.Exemption, error) {
+	sourceIP, err := parseIP(e.Source)
+	if err != nil {
+		return firewall.Exemption{}, err
+	}
+	destinationIP, err := parseIP(e.Destination)
+	if err != nil {
+		return firewall.Exemption{}, err
+	}
+
+	return firewall.Exemption{
+		Source:      sourceIP,
+		Destination: destinationIP,
+		Port:        e.Port,
+	}, nil
+}
+
+type Configuration struct {
+	Ingresses  []Ingress   `hcl:"ingress,block"`
+	Exemptions []Exemption `hcl:"exemption,block"`
+}
+
+func (c Configuration) ToFirewall() ([]firewall.Ingress, []firewall.Exemption, error) {
+	ingresses := make([]firewall.Ingress, len(c.Ingresses))
+	for i, ingress := range c.Ingresses {
+		firewallIngress, err := ingress.ToFirewall()
+		if err != nil {
+			return nil, nil, err
+		}
+		ingresses[i] = firewallIngress
+	}
+
+	exemptions := make([]firewall.Exemption, len(c.Exemptions))
+	for i, exemption := range c.Exemptions {
+		firewallExemption, err := exemption.ToFirewall()
+		if err != nil {
+			return nil, nil, err
+		}
+		exemptions[i] = firewallExemption
+	}
+
+	return ingresses, exemptions, nil
+}

--- a/config.hcl
+++ b/config.hcl
@@ -1,1 +1,15 @@
-interfaces = ["lo"]
+ingress {
+  address = "127.0.0.1"
+  port = 80
+}
+
+ingress {
+  address = "127.0.0.1"
+  port = 81
+}
+
+exemption {
+  source = "127.0.0.1"
+  destination = "127.0.0.1"
+  port = 80
+}

--- a/firewall/exemption.go
+++ b/firewall/exemption.go
@@ -1,0 +1,30 @@
+package firewall
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+)
+
+type Exemption struct {
+	Destination net.IP
+	Port        int
+	Source      net.IP
+}
+
+func (s *Exemption) String() string {
+	return fmt.Sprintf(
+		"%s --> %s:%d",
+		s.Source, s.Destination, s.Port,
+	)
+}
+
+func (r *Exemption) key() [10]byte {
+	key := [10]byte{}
+	destinationIP := r.Destination.To4()
+	sourceIP := r.Source.To4()
+	binary.BigEndian.PutUint32(key[0:4], binary.BigEndian.Uint32(sourceIP))
+	binary.BigEndian.PutUint32(key[4:8], binary.BigEndian.Uint32(destinationIP))
+	binary.BigEndian.PutUint16(key[8:10], uint16(r.Port))
+	return key
+}

--- a/firewall/ingress.go
+++ b/firewall/ingress.go
@@ -1,0 +1,30 @@
+package firewall
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+)
+
+type Ingress struct {
+	Address net.IP
+	Port    int
+}
+
+func (i *Ingress) String() string {
+	return fmt.Sprintf(
+		"%s:%d",
+		i.Address, i.Port,
+	)
+}
+
+func (i *Ingress) Interfaces() ([]net.Interface, error) {
+	return interfacesForIPv4(i.Address)
+}
+
+func (i *Ingress) key() [6]byte {
+	key := [6]byte{}
+	binary.BigEndian.PutUint32(key[0:4], binary.BigEndian.Uint32(i.Address.To4()))
+	binary.BigEndian.PutUint16(key[4:6], uint16(i.Port))
+	return key
+}

--- a/firewall/stats.go
+++ b/firewall/stats.go
@@ -6,18 +6,18 @@ const (
 	droppedPacket uint32 = 0
 )
 
-type Stats struct {
+type PacketStats struct {
 	Dropped uint64
 }
 
-func (s Stats) String() string {
+func (s PacketStats) String() string {
 	return fmt.Sprintf("Packets dropped: %d", s.Dropped)
 }
 
-func readPacketCounter(objs *bpfObjects) (Stats, error) {
-	stats := Stats{}
+func readPacketCounter(objs *bpfObjects) (PacketStats, error) {
+	stats := PacketStats{}
 	if err := objs.bpfMaps.PacketCounter.Lookup(droppedPacket, &stats.Dropped); err != nil {
-		return Stats{}, err
+		return PacketStats{}, err
 	}
 	return stats, nil
 }

--- a/firewall/stats.go
+++ b/firewall/stats.go
@@ -1,0 +1,23 @@
+package firewall
+
+import "fmt"
+
+const (
+	droppedPacket uint32 = 0
+)
+
+type packetStats struct {
+	Dropped uint64
+}
+
+func (s packetStats) String() string {
+	return fmt.Sprintf("Packets dropped: %d", s.Dropped)
+}
+
+func readPacketCounter(objs *bpfObjects) (packetStats, error) {
+	stats := packetStats{}
+	if err := objs.bpfMaps.PacketCounter.Lookup(droppedPacket, &stats.Dropped); err != nil {
+		return packetStats{}, err
+	}
+	return stats, nil
+}

--- a/firewall/stats.go
+++ b/firewall/stats.go
@@ -6,18 +6,18 @@ const (
 	droppedPacket uint32 = 0
 )
 
-type packetStats struct {
+type Stats struct {
 	Dropped uint64
 }
 
-func (s packetStats) String() string {
+func (s Stats) String() string {
 	return fmt.Sprintf("Packets dropped: %d", s.Dropped)
 }
 
-func readPacketCounter(objs *bpfObjects) (packetStats, error) {
-	stats := packetStats{}
+func readPacketCounter(objs *bpfObjects) (Stats, error) {
+	stats := Stats{}
 	if err := objs.bpfMaps.PacketCounter.Lookup(droppedPacket, &stats.Dropped); err != nil {
-		return packetStats{}, err
+		return Stats{}, err
 	}
 	return stats, nil
 }

--- a/firewall/utils.go
+++ b/firewall/utils.go
@@ -1,0 +1,70 @@
+package firewall
+
+import "net"
+
+var globalListener = net.IPv4(0, 0, 0, 0)
+
+func dedupExemptions(exemptions []Exemption) []Exemption {
+	exemptionSet := make(map[[10]byte]Exemption)
+	for _, exemption := range exemptions {
+		exemptionSet[exemption.key()] = exemption
+	}
+
+	deduped := []Exemption{}
+	for _, exemption := range exemptionSet {
+		deduped = append(deduped, exemption)
+	}
+	return deduped
+}
+
+func dedupIngresses(ingresses []Ingress) []Ingress {
+	ingressSet := make(map[[6]byte]Ingress)
+	for _, ingress := range ingresses {
+		ingressSet[ingress.key()] = ingress
+	}
+
+	deduped := []Ingress{}
+	for _, ingress := range ingressSet {
+		deduped = append(deduped, ingress)
+	}
+	return deduped
+}
+
+func dedupInterfaces(interfaces []net.Interface) []net.Interface {
+	interfaceSet := make(map[int]net.Interface)
+	for _, iface := range interfaces {
+		interfaceSet[iface.Index] = iface
+	}
+
+	deduped := []net.Interface{}
+	for _, iface := range interfaceSet {
+		deduped = append(deduped, iface)
+	}
+	return deduped
+}
+
+func interfacesForIPv4(ip net.IP) ([]net.Interface, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	if ip.Equal(globalListener) {
+		return interfaces, nil
+	}
+	filtered := []net.Interface{}
+	for _, iface := range interfaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return nil, err
+		}
+		for _, addr := range addrs {
+			if address, ok := addr.(*net.IPNet); ok {
+				if ip.Equal(address.IP.To4()) {
+					filtered = append(filtered, iface)
+					break
+				}
+			}
+		}
+	}
+	return filtered, nil
+}

--- a/firewall/xdp.go
+++ b/firewall/xdp.go
@@ -2,54 +2,42 @@ package firewall
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net"
+	"sync"
 	"time"
 
+	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 )
 
 //go:generate bpf2go -strip $BPF_STRIP -cc $BPF_CLANG -cflags $BPF_CFLAGS bpf xdp.c -- -I./headers
 
-const (
-	ipPacket   uint32 = 0
-	ipv6Packet uint32 = 1
+var (
+	// since we're working with a global eBPF module
+	// these variables are used to track the global
+	// state of the module
+	updateMutex        sync.Mutex
+	objects            bpfObjects
+	attachedLinks      []link.Link
+	attachedIngresses  []Ingress
+	attachedExemptions []Exemption
 )
 
-type packetStats struct {
-	IP   uint64
-	IPv6 uint64
+func init() {
+	if err := loadBpfObjects(&objects, nil); err != nil {
+		log.Fatalf("error loading bpf program: %v", err)
+	}
 }
 
-func (s packetStats) String() string {
-	return fmt.Sprintf("Packets received: IP - %d, IPv6 - %d", s.IP, s.IPv6)
-}
-
-func Start(ctx context.Context, interfaces []net.Interface) error {
-	objs := bpfObjects{}
-	if err := loadBpfObjects(&objs, nil); err != nil {
-		return err
-	}
-
-	for _, iface := range interfaces {
-		xdp, err := link.AttachXDP(link.XDPOptions{
-			Program:   objs.Classifier,
-			Interface: iface.Index,
-		})
-		if err != nil {
-			return err
-		}
-		defer xdp.Close()
-	}
-
-	ticker := time.NewTicker(1 * time.Second)
+func Poll(ctx context.Context, timeout time.Duration) error {
+	ticker := time.NewTicker(timeout)
 	current := packetStats{}
 
 	for {
 		select {
 		case <-ticker.C:
-			stats, err := readPacketCounter(&objs)
+			stats, err := readPacketCounter(&objects)
 			if err != nil {
 				return err
 			}
@@ -63,13 +51,115 @@ func Start(ctx context.Context, interfaces []net.Interface) error {
 	}
 }
 
-func readPacketCounter(objs *bpfObjects) (packetStats, error) {
-	stats := packetStats{}
-	if err := objs.bpfMaps.PacketCounter.Lookup(ipPacket, &stats.IP); err != nil {
-		return packetStats{}, err
+func Update(ingresses []Ingress, exemptions []Exemption) error {
+	updateMutex.Lock()
+	defer updateMutex.Unlock()
+
+	ingresses = dedupIngresses(ingresses)
+	exemptions = dedupExemptions(exemptions)
+	interfaces := []net.Interface{}
+	for _, ingress := range ingresses {
+		ingressInterfaces, err := ingress.Interfaces()
+		if err != nil {
+			return err
+		}
+		interfaces = append(interfaces, ingressInterfaces...)
 	}
-	if err := objs.bpfMaps.PacketCounter.Lookup(ipv6Packet, &stats.IPv6); err != nil {
-		return packetStats{}, err
+	interfaces = dedupInterfaces(interfaces)
+
+	if err := detachAll(); err != nil {
+		return err
 	}
-	return stats, nil
+
+	return attach(ingresses, interfaces, exemptions)
+}
+
+func Cleanup() error {
+	updateMutex.Lock()
+	defer updateMutex.Unlock()
+
+	return detachAll()
+}
+
+func detachAll() error {
+	for _, link := range attachedLinks {
+		if err := link.Close(); err != nil {
+			return err
+		}
+	}
+	attachedLinks = []link.Link{}
+
+	// remove our watched ingresses
+	existingIngresses := [][6]byte{}
+	for _, ingress := range attachedIngresses {
+		existingIngresses = append(existingIngresses, ingress.key())
+	}
+	if len(existingIngresses) > 0 {
+		_, err := objects.Ingresses.BatchDelete(existingIngresses, &ebpf.BatchOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	attachedIngresses = []Ingress{}
+
+	// remove our exemptions
+	existingExemptions := [][10]byte{}
+	for _, exemption := range attachedExemptions {
+		existingExemptions = append(existingExemptions, exemption.key())
+	}
+	if len(existingExemptions) > 0 {
+		_, err := objects.Exemptions.BatchDelete(existingExemptions, &ebpf.BatchOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	attachedExemptions = []Exemption{}
+
+	return nil
+}
+
+func attach(ingresses []Ingress, interfaces []net.Interface, exemptions []Exemption) error {
+	// add desired ingresses
+	ingressKeys := [][6]byte{}
+	ingressValues := []uint8{}
+	for _, ingress := range ingresses {
+		ingressKeys = append(ingressKeys, ingress.key())
+		ingressValues = append(ingressValues, uint8(0))
+	}
+	if len(ingressKeys) > 0 {
+		_, err := objects.Ingresses.BatchUpdate(ingressKeys, ingressValues, &ebpf.BatchOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	attachedIngresses = ingresses
+
+	// add desired exemptions
+	exemptionKeys := [][10]byte{}
+	exemptionValues := []uint8{}
+	for _, exemption := range exemptions {
+		exemptionKeys = append(exemptionKeys, exemption.key())
+		exemptionValues = append(exemptionValues, uint8(0))
+	}
+	if len(exemptionKeys) > 0 {
+		_, err := objects.Exemptions.BatchUpdate(exemptionKeys, exemptionValues, &ebpf.BatchOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	attachedExemptions = exemptions
+
+	// attach the bpf program to the desired interfaces
+	for _, iface := range interfaces {
+		xdp, err := link.AttachXDP(link.XDPOptions{
+			Program:   objects.Classifier,
+			Interface: iface.Index,
+		})
+		if err != nil {
+			return err
+		}
+		attachedLinks = append(attachedLinks, xdp)
+	}
+
+	return nil
 }

--- a/firewall/xdp.go
+++ b/firewall/xdp.go
@@ -22,6 +22,10 @@ var (
 	attachedLinks      []link.Link
 	attachedIngresses  []Ingress
 	attachedExemptions []Exemption
+
+	// this is a global channel where we send stat
+	// updates
+	Stats = make(chan PacketStats, 1)
 )
 
 func init() {
@@ -30,9 +34,9 @@ func init() {
 	}
 }
 
-func Poll(ctx context.Context, timeout time.Duration, stats chan Stats) error {
+func Poll(ctx context.Context, timeout time.Duration) error {
 	ticker := time.NewTicker(timeout)
-	current := Stats{}
+	current := PacketStats{}
 
 	for {
 		select {
@@ -43,7 +47,7 @@ func Poll(ctx context.Context, timeout time.Duration, stats chan Stats) error {
 			}
 			if updated != current {
 				select {
-				case stats <- updated:
+				case Stats <- updated:
 					current = updated
 				default:
 					// drop and pick up the stats update next time

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 func main() {
-	stop := make(chan os.Signal)
+	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
 
 	var configFile string

--- a/main.go
+++ b/main.go
@@ -52,15 +52,13 @@ func main() {
 	}
 	defer firewall.Cleanup()
 
-	stats := make(chan firewall.Stats, 1)
-
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		for {
 			select {
-			case stats := <-stats:
+			case stats := <-firewall.Stats:
 				log.Println(stats)
 			case <-ctx.Done():
 				return
@@ -68,7 +66,7 @@ func main() {
 		}
 	}()
 
-	if err := firewall.Poll(ctx, 1*time.Second, stats); err != nil {
+	if err := firewall.Poll(ctx, 1*time.Second); err != nil {
 		log.Fatalf("error linking XDP program: %v", err)
 	}
 


### PR DESCRIPTION
So, basic way this works is that you hand a couple of blocks of configuration to define "ingresses" (basically a service address/port pair you're wanting to protect), and "exemptions" (source ips that you want to be able to allow through said ingresses).

In the userspace side of things we read from a config file and call `firewall.Update` to dump the ingress/exemption configuration to our eBPF maps that our xdp program reads as it processes packets (ideally in the future the syncing code from the Consul catalog would populate the ingress/exemption values and call `firewall.Update` on change).

Since we're working with structures across Go/C boundaries we do some simple binary encoding on the Go side of things and use packed C structures to make sure we don't run into any structure padding issues.

In the xdp code we parse/unwrap ethernet -> ip -> tcp/udp and grab our source/destination ips from the ip header and the target ports from the protocol-specific headers. We then check: 1) is this destination ip/port registered as an ingress we watch? and 2) do we have an explicit exemption for this source for the given ingress? We can summarize the result as:

|   | Ingress Found |  Ingress Not Found |
|---|---|---|
| Exemption Found | XDP_PASS | XDP_PASS |
| Exemption Not Found | XDP_DROP | XDP_PASS |

This way we _only_ drop traffic for interfaces and ports that we actually know we want to manage. I have some ideas around some simple wildcarding behavior we can pretty easily add too if we want to do things like manage all accesses to port 80 on any interface or manage all ports on a given interface and the like if we're interested.

One additional question I had, did we need to support IPv6? I don't think I've ever tried using IPv6 in Consul, so not entirely sure whether we'd be able to do the reconstruction to a set of IPv6 addresses given service intentions.